### PR TITLE
adds types to exports to resolve tsc error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   ],
   "exports": {
     "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
+
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Helps to resolve the following build error:

```console
$ tsc && vite build
src/hooks/auth.ts:1:31 - error TS7016: Could not find a declaration file for module 'react-query-auth'. '/path/to/project/node_modules/react-query-auth/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/path/to/project/node_modules/react-query-auth/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-query-auth' library may need to update its package.json or typings.

1 import { configureAuth } from "react-query-auth";
                                ~~~~~~~~~~~~~~~~~~


Found 1 error in src/hooks/auth.ts:1
```
